### PR TITLE
don't validate formula if it hasn't been updated

### DIFF
--- a/src/routes/customKeyFigureRoutes.js
+++ b/src/routes/customKeyFigureRoutes.js
@@ -117,8 +117,11 @@ router.patch("/:id", authenticateAdmin, async (req, res, next)=>{
         return res.status(400).json({message: `custom key figure with name ${customKeyFigureJson.name} already exists`})
     }
 
-    if (await validateFormula(customKeyFigureJson.formula) === false) {
-        return res.status(400).json({message: "invalid formula"})
+    if (customKeyFigureJson.hasOwnProperty("formula")) {
+        // Only validate formula if it has been updated
+        if (await validateFormula(customKeyFigureJson.formula) === false) {
+            return res.status(400).json({message: "invalid formula"})
+        }
     }
 
     /*


### PR DESCRIPTION
Fixed a bug in PATCH /customKeyFigures where the formula of an updated custom key figure would be validated even if it hasn't been updated. Due to unmodified attributes not being included in the request payload, this would cause an error because the formula was undefined.
Now, the formula only is being validated, when the attribute is present inside the JSON object