### PR TITLE
made .env path independent from node cwd

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,8 @@ const keyFigureRoutes = require("./routes/keyFigureRoutes")
 const connectDB = require("../scripts/db")
 const seedDB = require("../scripts/seedDB")
 
-require('dotenv').config();
+const dotenvPath = path.resolve(__dirname, "../.env")
+require('dotenv').config({path: dotenvPath})
 
 const swaggerPath = path.join(__dirname, "../swagger.yaml")
 const swaggerDocument = YAML.load(swaggerPath)


### PR DESCRIPTION
Made .env path independent from node cwd by using `path.resolve()` for the dotenv config path
(Issue #67)