### PR TITLE
fix faulty regex pattern

### DIFF
--- a/src/utils/validateUserInput.js
+++ b/src/utils/validateUserInput.js
@@ -7,7 +7,7 @@ function validateInput(input) {
      * @param {String} input - The user input from a request
      * @returns {Boolean} True, if the input is valid, falso otherwise
      */
-    const regex = /^[A-Za-z0-9\s!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~]*$/;
+    const regex = /^[a-zA-Z0-9\s\-_,.()]+$/;
     return regex.test(input);
 }
 


### PR DESCRIPTION
The original regex pattern for the anti XSS / NoSQL injection validation blocked every single input. That (somehow) went unnoticed during testing of the new feature. It should work now.