### PR TITLE
add /api prefix to all routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -33,11 +33,11 @@ app.use(morgan(":date[clf]  :remote-addr  :status  :methodPad :urlPad :response-
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-app.use("/auth", authRoutes)
-app.use("/upload", uploadRoutes)
-app.use("/companies", companyRoutes)
-app.use("/customKeyFigures", customKeyFigureRoutes)
-app.use("/keyFigures", keyFigureRoutes)
+app.use("/api/auth", authRoutes)
+app.use("/api/upload", uploadRoutes)
+app.use("/api/companies", companyRoutes)
+app.use("/api/customKeyFigures", customKeyFigureRoutes)
+app.use("/api/keyFigures", keyFigureRoutes)
 
 
 // Automatically respond with 500 when next(err) is called in an endpoint


### PR DESCRIPTION
Added the /api prefix to all routes so that the API tests also work locally.