### PR TITLE
use admin token to test POST endpoints

### DIFF
--- a/src/tests/API_tests/keyFigureRoutes.test.js
+++ b/src/tests/API_tests/keyFigureRoutes.test.js
@@ -122,7 +122,7 @@ describe('KeyFigure Routes Testing', () => {
                 formula: undefined,
                 type:  'percentage'
             }, {
-                headers: {'Authorization': `Bearer ${tokens.standard}`}
+                headers: {'Authorization': `Bearer ${tokens.admin}`}
             });
             throw new Error('it should not come this far')
 
@@ -136,7 +136,7 @@ describe('KeyFigure Routes Testing', () => {
                 formula: 'cash / (bank + postal)',
                 type:  'numeric'
             }, {
-                headers: {'Authorization': `Bearer ${tokens.standard}`}
+                headers: {'Authorization': `Bearer ${tokens.admin}`}
             });
             throw new Error('it should not come this far')
 
@@ -150,7 +150,7 @@ describe('KeyFigure Routes Testing', () => {
                 formula: 'cash / (bank + postal)',
                 type:  undefined
             }, {
-                headers: {'Authorization': `Bearer ${tokens.standard}`}
+                headers: {'Authorization': `Bearer ${tokens.admin}`}
             });
             throw new Error('it should not come this far')
 
@@ -196,7 +196,7 @@ describe('KeyFigure Routes Testing', () => {
                 formula: 'cash / (bank + postal)',
                 type:  'numeric'
             }, {
-                headers: {'Authorization': `Bearer ${tokens.standard}`}
+                headers: {'Authorization': `Bearer ${tokens.admin}`}
             });
             expect(res.status).toBe(201);
             expect(res.data.message).toBe('custom key figure created successfully')


### PR DESCRIPTION
While doing a routine execution of the api tests on the webserver, i noticed that three api tests were failing. After investigating the failing tests, I found that all of them were trying to access admin only endpoints with a standard token. These tokens did not test 403 responses or any aspect of authorization, they expected 400 or 201 responses. So i fixed that, now all tests pass (again)

I didn't find out when this bug was introduced because all API tests passed successfully on the 29.4.